### PR TITLE
Add row index to provider (+ typo)

### DIFF
--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -37,13 +37,13 @@
   }
 
   let dataURL = [];
-  let bolbURL = [];
+  let blobURL = [];
   let name = [];
   let type = [];
   let size = [];
   $: if (data && data.length > 2) {
     dataURL = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => e.link): [];
-    bolbURL = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => dataURIToBlobURL(e.link)): [];
+    blobURL = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => dataURIToBlobURL(e.link)): [];
     name = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => e.name): [];
     type = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => e.type): [];
     size = data? JSON.parse((encodingProtection? data.slice(1,-1): data)).map((e) => e.size): [];
@@ -53,7 +53,7 @@
 
 <div use:styleable={$component.styles}>
   {#each dataURL as url, i}
-        <Provider data={{dataURL:url, blobURL: bolbURL[i], name: name[i], type: type[i], size: size[i]}}>
+        <Provider data={{dataURL:url, blobURL: blobURL[i], name: name[i], type: type[i], size: size[i], rowIndex: i}}>
         <slot />
       </Provider>
       {/each}


### PR DESCRIPTION
Hi,
I propose to add the row index to the provider (like a regular data repeater has).
My use case is the following: I need to store properties for each file in a dedicated array. Having the index in the context provider will help me extract and display the right property for the right row.
Also, I fixed a typo error.